### PR TITLE
Don't overwrite the the classes own "boot" method

### DIFF
--- a/src/Loggable.php
+++ b/src/Loggable.php
@@ -13,8 +13,6 @@ trait Loggable
      */
     public static function bootLoggable()
     {
-        parent::boot();
-
         self::created(function ($model) {
             self::log($model, 'create');
         });

--- a/src/Loggable.php
+++ b/src/Loggable.php
@@ -11,7 +11,7 @@ trait Loggable
      *
      * @return void
      */
-    public static function boot()
+    public static function bootLoggable()
     {
         parent::boot();
 


### PR DESCRIPTION
Overwriting the `boot` method of the class the trait is applied to is a pretty bad idea - it's an unwritten barrier to using the package because it means people can't have their own boot methods without having to use annoying trait method name aliases.

Luckily Laravel offers a way around that, it'll automatically run the boot method for any traits in the class if the method follows the convention `bootTraitName`

This PR just changes the name of the method to do that.